### PR TITLE
Ensure no shit happens when client_secret is null

### DIFF
--- a/src/default.js
+++ b/src/default.js
@@ -96,7 +96,7 @@ module.exports = function DefaultNodeTokens(tokenConfig, config) {
                 .query({
                     realm: REALM
                 })
-                .auth(client.client_id, client.client_secret)
+                .auth(client.client_id, client.client_secret || '')
                 .type('form')
                 .send({
                     grant_type: 'password',


### PR DESCRIPTION
Because it will probably be concatenated under the hood and in Javascript this is true: `("a string is " + null) === "a string is null"` :broken_heart: