### PR TITLE
7 proper error logging

### DIFF
--- a/src/default.js
+++ b/src/default.js
@@ -61,11 +61,11 @@ module.exports = function DefaultNodeTokens(tokenConfig, config) {
                 constructValidityRequestFn(tokenName)
                 .end((err, response) => {
                     if (err) {
-                        winston.debug(PACKAGE_NAME, 'Token', tokenName, 'is invalid.');
+                        winston.debug('%s Token "%s" is invalid.', PACKAGE_NAME, tokenName);
                         return reject(err);
                     }
                     //TODO edge case where token is still valid but like two seconds.
-                    winston.debug(PACKAGE_NAME, 'Token', tokenName, 'is still valid.');
+                    winston.debug('%s Token "%s" is still valid for %s seconds.', PACKAGE_NAME, tokenName, response.body.expires_in);
                     resolve(response.body);
                 });
             });
@@ -73,7 +73,7 @@ module.exports = function DefaultNodeTokens(tokenConfig, config) {
 
         if (tokeninfo.local_expiry < Date.now()) {
             var msg = `Token ${tokenName} expired locally.`;
-            winston.debug(PACKAGE_NAME, msg);
+            winston.debug('%s %s', PACKAGE_NAME, msg);
             return Promise.reject(new Error(msg));
         }
         return Promise.resolve(tokeninfo);
@@ -121,7 +121,7 @@ module.exports = function DefaultNodeTokens(tokenConfig, config) {
             constructObtainRequestFn(tokenName)
             .end((err, response) => {
                 if (err) {
-                    winston.error('Could not obtain token', tokenName, err);
+                    winston.error('%s Could not obtain token "%s": %d %s', PACKAGE_NAME, tokenName, err.status, err.message);
                     return reject(err);
                 }
                 resolve(response.body);
@@ -140,7 +140,7 @@ module.exports = function DefaultNodeTokens(tokenConfig, config) {
         if (tokenResponse && !tokenResponse.local_expiry) {
             TOKENS[tokenName] = tokenResponse;
             TOKENS[tokenName].local_expiry = Date.now() + tokenResponse.expires_in * 1000 - EXPIRE_THRESHOLD;
-            winston.info(PACKAGE_NAME, 'Obtained new token', tokenName);
+            winston.info('%s Obtained new token "%s".', PACKAGE_NAME, tokenName);
         }
         // else just return what we have already
         return TOKENS[tokenName];

--- a/src/default.js
+++ b/src/default.js
@@ -121,7 +121,7 @@ module.exports = function DefaultNodeTokens(tokenConfig, config) {
             constructObtainRequestFn(tokenName)
             .end((err, response) => {
                 if (err) {
-                    winston.error('%s Could not obtain token "%s": %d %s', PACKAGE_NAME, tokenName, err.status, err.message);
+                    winston.error('%s Could not obtain token "%s": %d %s. Metadata: %j', PACKAGE_NAME, tokenName, err.status, err.message, err.response.body);
                     return reject(err);
                 }
                 resolve(response.body);

--- a/src/default.js
+++ b/src/default.js
@@ -121,7 +121,7 @@ module.exports = function DefaultNodeTokens(tokenConfig, config) {
             constructObtainRequestFn(tokenName)
             .end((err, response) => {
                 if (err) {
-                    winston.error('%s Could not obtain token "%s": %d %s. Metadata: %j', PACKAGE_NAME, tokenName, err.status, err.message, err.response.body);
+                    winston.error('%s Could not obtain token "%s": %d %s. Response body: %j', PACKAGE_NAME, tokenName, err.status, err.message, (err.response && err.response.body));
                     return reject(err);
                 }
                 resolve(response.body);

--- a/src/default.js
+++ b/src/default.js
@@ -5,7 +5,7 @@ var superagent = require('superagent'),
     fs = require('fs');
 
 module.exports = function DefaultNodeTokens(tokenConfig, config) {
-    winston.info(PACKAGE_NAME, 'Running in default mode.');
+    winston.info('%s Running in default mode.', PACKAGE_NAME);
 
     var tokenConfig = tokenConfig || {},
         config = config || {},
@@ -49,7 +49,7 @@ module.exports = function DefaultNodeTokens(tokenConfig, config) {
     function checkTokenValidity(tokenName) {
         if (!TOKENS[tokenName]) {
             var msg = `Token ${tokenName} does not exist.`;
-            winston.debug(PACKAGE_NAME, msg);
+            winston.debug('%s %s', PACKAGE_NAME, msg);
             return Promise.reject(new Error(msg));
         }
         var tokeninfo = TOKENS[tokenName];

--- a/src/local.js
+++ b/src/local.js
@@ -2,7 +2,7 @@ var winston = require('winston'),
     PACKAGE_NAME = '[node-tokens]';
 
 module.exports = function LocalNodeTokens() {
-    winston.info(PACKAGE_NAME, 'Running in local mode.');
+    winston.info('%s Running in local mode.', PACKAGE_NAME);
 
     var tokenString = process.env.OAUTH_ACCESS_TOKENS;
         tokens = tokenString

--- a/test/default.test.js
+++ b/test/default.test.js
@@ -21,7 +21,11 @@ var createTokens = require('../src/default'),
         application_password: 'password'
     },
     SA_PASS = {
-        end: cb => cb(null, {})
+        end: cb => cb(null, {
+            body: {
+                expires_in: 1000
+            }
+        })
     },
     SA_FAIL = {
         end: cb => cb(new Error('Superagent failure'), null)
@@ -148,7 +152,7 @@ describe('node-tokens in default mode', () => {
 
             t
             .checkTokenValidity('test')
-            .then(done);
+            .then(() => done());
         });
 
         it('should reject when validity failed', done => {
@@ -171,7 +175,7 @@ describe('node-tokens in default mode', () => {
 
             t
             .obtainToken('test')
-            .then(done);
+            .then(() => done());
         });
 
         it('should reject if token could not be obtained', done => {


### PR DESCRIPTION
Fixes #7

This PR removes the stack trace from an unsuccessful HTTP request and instead prints status and message, ie "401 Unauthorized", followed by the response body if available.