### PR TITLE
#8 backoff exponentially if at least one token could not be updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ tokens.get('kio');
 
 * `expirationThreshold`: Say you want to get a new token 2 minutes before the token actually expires. Then you would set this to `120000`. Defaults to 60 seconds.
 * `refreshInterval`: How often you want your tokens to be checked for validity, in ms. Defaults to 10 seconds.
+* `backoffFactor`: Factor to multiply the refresh interval when backing off. Defaults to 2, so it would go 100, 200, 400… for a configured interval of 100 ms.
+* `maxRefreshInterval`: The maximum interval when backing off. Defaults to 5 minutes.
 * `realm`: Realm you want your token to be valid for. Defaults to "/services".
 * `credentialsDir`: Where to get client and user credentials, usually already set by Taupage. No default.
 * `oauthTokeninfoUrl`: Where to get information about a token. No default!
@@ -40,6 +42,8 @@ tokens.get('kio');
 
 You can set the following environment variables to configure the corresponding option:
 
+* `TOKENS_BACKOFF_FACTOR`
+* `TOKENS_MAX_REFRESH_INTERVAL`
 * `TOKENS_EXPIRATION_THRESHOLD`
 * `TOKENS_REFRESH_INTERVAL`
 * `CREDENTIALS_DIR`

--- a/src/default.js
+++ b/src/default.js
@@ -187,8 +187,10 @@ module.exports = function DefaultNodeTokens(tokenConfig, config) {
         Promise
         .all(updatePromises)
         .then((res) => {
-            winston.debug('%s All updates were good, resetting refresh interval.', PACKAGE_NAME);
-            refreshInterval = REFRESH_INTERVAL;
+            if (refreshInterval > REFRESH_INTERVAL) {
+                winston.debug('%s All updates were good, resetting refresh interval.', PACKAGE_NAME);
+                refreshInterval = REFRESH_INTERVAL;
+            }
             setTimeout(scheduleUpdates, refreshInterval);
         })
         .catch(err => {

--- a/test/default.test.js
+++ b/test/default.test.js
@@ -279,6 +279,24 @@ describe('node-tokens in default mode', () => {
             }, 1000);
         });
 
+        it('should reset the backoff again', done => {
+            var stub = sinon.stub();
+            stub.returns(Promise.reject());
+            t = createTokens(TEST_TOKENS, Object.assign(DEFAULT_CONFIG, {
+                updateTokenFn: stub
+            }));
+            t.scheduleUpdates();
+            setTimeout(() => {
+                stub.returns(Promise.resolve());
+            }, 400);
+            setTimeout(() => {
+                t.stop();
+                expect(stub.callCount).to.equal(9);
+                done();
+            }, 1000);
+        });
+
+
         it('should cap the backoff at configured maximum', done => {
             var stub = sinon.stub();
             stub.returns(Promise.reject());
@@ -291,9 +309,9 @@ describe('node-tokens in default mode', () => {
                 t.stop();
                 // default backoff factor is 2
                 // should work like so: 100, 200, 400, 400
-                expect(stub.callCount).to.equal(4);
+                expect(stub.callCount).to.equal(5);
                 done();
-            }, 1000);
+            }, 1500);
         });
     });
 });


### PR DESCRIPTION
Fixes #8

This PR introduces a configurable exponential backoff if at least one of the managed tokens could not be updated.